### PR TITLE
Feature/add self adjudication

### DIFF
--- a/bin/accept_ballot.py
+++ b/bin/accept_ballot.py
@@ -106,7 +106,9 @@ def checkout_new_contest_branch(contest, ref_branch):
     raise Exception(f"could not create git branch {branch} on the third attempt")
 
 def get_unmerged_contests(config):
-    """Queries git for the unmerged CVRs.
+    """Queries git for the unmerged CVRs and returns the list.  See
+    Shellout.cvr_parse_git_log_output for more info.  The returned
+    list is still in git log order.
     """
     # Mmm, at the moment the thought is that we need all the unmerged
     # contests and ignore anything already merged.  So first get the
@@ -142,7 +144,6 @@ def get_cloaked_contests(contest, branch):
 
 def contest_add_and_commit(branch):
     """Will git add and commit the new contest content.
-
     Requires the CWD to be the parent of the CVRs directory.
     """
     # If this fails a shell error will be raised
@@ -160,6 +161,53 @@ def contest_add_and_commit(branch):
                      check=True, capture_output=True, text=True).stdout.strip()
     return digest
 
+def create_ballot_receipt(the_ballot, contest_receipts, unmerged_cvrs, the_election_config):
+    """
+    Create the voter's receipt.
+    """
+    ballot_receipt = []
+#    import pdb; pdb.set_trace()
+    # Not 0 based
+    voters_row = random.randint(1,Globals.get('BALLOT_RECEIPT_ROWS'))
+    # When there are not enough unmerged_receipts to print a receipt
+    redacted_uids = set()
+    # Add column headers
+    ballot_receipt.append(','.join(unmerged_cvrs.keys()))
+    for row in range(Globals.get('BALLOT_RECEIPT_ROWS') - 1):
+        if row == voters_row - 1:
+            # Include the voter's receipts instead
+            ballot_receipt.append(','.join(contest_receipts.values()))
+            # But can just keep going as well
+        next_row = []
+        # Note - these are the voter's uids and digests
+        for uid, digest in contest_receipts.items():
+            if uid not in unmerged_cvrs:
+                # Actually, there are _no_ other such cast uid's in
+                # this case
+                redacted_uids.add(uid)
+                next_row.append("INSUFFICIENT_CVRS")
+            elif row > len(unmerged_cvrs[uid]):
+                redacted_uids.add(uid)
+                next_row.append("INSUFFICIENT_CVRS")
+            elif digest == unmerged_cvrs[uid][row]['digest']:
+                # This is the voter's own digest!
+                if row + 1 > len(unmerged_cvrs[uid]):
+                    redacted_uids.add(uid)
+                    next_row.append("INSUFFICIENT_CVRS")
+                else:
+                    next_row.append(unmerged_cvrs[uid][row + 1]['digest'])
+            else:
+                next_row.append(unmerged_cvrs[uid][row]['digest'])
+        ballot_receipt.append(','.join(next_row))
+    # Now need to redact any uid column that contains one or more
+    # INSUFFICIENT_CVRS
+
+    # Now write out the ballot_receipt in csv for now - can deal with
+    # html (URL links) and a pdf (printable) later - both still a TBD.
+    receipt_file = the_ballot.write_receipt_csv(ballot_receipt, the_election_config)
+    # print the voter's row to STDOUT for now
+    print(f"############\n### Receipt file: {receipt_file}")
+    print(f"### Voter's row: {voters_row}\n############")
 
 ################
 # arg parsing
@@ -235,7 +283,7 @@ def main():
         a_ballot.read_a_cast_ballot(the_address, the_election_config)
 
     # the voter's row of digests (indexed by contest uid)
-    ballot_receipts = {}
+    contest_receipts = {}
     # a cloaked receipt
     cloak_receipts = {}
     # 100 additional contest receipts
@@ -289,14 +337,13 @@ def main():
                 # Write out the voter's contest to CVRs/contest.json
                 a_ballot.write_contest(contest, the_election_config)
                 # commit the voter's contest
-                ballot_receipts[uid] = contest_add_and_commit(branches[-1])
+                contest_receipts[uid] = contest_add_and_commit(branches[-1])
                 # if cloaking, get those as well
                 if 'cloak' in contest.get('contest'):
                     cloak_receipts[uid] = get_cloaked_contests(contest, 'master')
         # After all the contests digests have been generated as well
         # as the others and cloaks as much as possible, then push as
         # atomically as possible all the contests.
-#        import pdb; pdb.set_trace()
         for branch in branches:
             Shellout.run(
                 ['git', 'push', 'origin', branch],
@@ -305,32 +352,14 @@ def main():
         # pushed copies will be pruned since there can be too many
         # there from all the possible scanner instances.
 
-    debug(f"Ballot's digests:\n{ballot_receipts}")
-    # print the other receitps
-    print("################\nPrinting up to 100 unmerged other contests:")
+    debug(f"Ballot's digests:\n{contest_receipts}")
+    # Shuffled the unmerged_cvrs (an inplace shuffle) - only need to
+    # shuffle the uids for this ballot.
 #    import pdb; pdb.set_trace()
-    for uid, digest in ballot_receipts.items():
-        col = 0
-        row = 0
-        print(f"{uid}:", end='')
-        if uid not in unmerged_cvrs:
-            print(" <no CVRs found>")
-            continue
-        for cvr in unmerged_cvrs[uid]:
-            if digest != cvr['digest']:
-                print(f" {cvr['digest'][0:8]}", end='')
-                col += 1
-            if col == 10:
-                if row == 9:
-                    break
-                print('\n' + f"{uid}:", end='')
-                col = 0
-                row += 1
-        print()
-    # print the voter's receipts
-    print("################\nBallot receipts (contest: key):")
-    for uid, digest in ballot_receipts.items():
-        print(f"{uid}: {digest}")
+    for uid in contest_receipts:
+        random.shuffle(unmerged_cvrs[uid])
+    # Create the ballot receipt
+    create_ballot_receipt(a_ballot, contest_receipts, unmerged_cvrs, the_election_config)
 
 if __name__ == '__main__':
     args = parse_arguments()

--- a/bin/accept_ballot.py
+++ b/bin/accept_ballot.py
@@ -163,7 +163,9 @@ def contest_add_and_commit(branch):
 
 def create_ballot_receipt(the_ballot, contest_receipts, unmerged_cvrs, the_election_config):
     """
-    Create the voter's receipt.
+    Create the voter's receipt.  As of this writing this is basically
+    a csv file with a header line with one row in particular being the
+    voter's.
     """
     ballot_receipt = []
 #    import pdb; pdb.set_trace()
@@ -171,8 +173,14 @@ def create_ballot_receipt(the_ballot, contest_receipts, unmerged_cvrs, the_elect
     voters_row = random.randint(1,Globals.get('BALLOT_RECEIPT_ROWS'))
     # When there are not enough unmerged_receipts to print a receipt
     redacted_uids = set()
-    # Add column headers
-    ballot_receipt.append(','.join(unmerged_cvrs.keys()))
+    # Add column headers - but include the long names as well
+    next_row = []
+    for uid in contest_receipts:
+        next_row.append(
+            '"' + uid + ' - ' + the_ballot.get_contest_name_by_uid(uid).replace('"',"'") + '"')
+    ballot_receipt.append(','.join(next_row))
+    # Loop BALLOT_RECEIPT_ROWS times (the rows) filling in the ballots
+    # uids as the columns.
     for row in range(Globals.get('BALLOT_RECEIPT_ROWS') - 1):
         if row == voters_row - 1:
             # Include the voter's receipts instead

--- a/bin/ballot.py
+++ b/bin/ballot.py
@@ -45,6 +45,10 @@ class Contests:
 
     def __iter__(self):
         """boilerplate"""
+        # start - be kind and reset things
+        self.ggo_index = 0
+        self.contest_index = 0
+        self.contest_max = len(self.ballot_ref.get('contests')[self.ggos[0]])
         return self
 
     def __next__(self):
@@ -170,6 +174,10 @@ class Ballot:
                       'ballot_subdir': self.ballot_subdir}
         return json.dumps(ballot, sort_keys=True, indent=4, ensure_ascii=False)
 
+    def clear_selection(self, contest):
+        """Clear the selection (as when self adjudicating)"""
+        self.contests[contest.get('ggo')][contest.get('index')][contest.get('name')]['selection'] = []
+
     def add_selection(self, contest, selection_offset):
         """
         Will add the specified contest choice (offset into the ordered
@@ -198,7 +206,7 @@ class Ballot:
         # name just because a string is more understandable than json
         # list syntax
         self.contests[contest_ggo][contest_index][contest_name]['selection'].append(
-            str(selection_offset) + ':  ' + contest.get['choices'][selection_offset])
+            str(selection_offset) + ': ' + contest.get('choices')[selection_offset])
 
     def verify_cast_ballot(self):
         """Will validate the ballot contest choices are legitimate.

--- a/bin/ballot.py
+++ b/bin/ballot.py
@@ -128,6 +128,15 @@ class Ballot:
                     Globals.get('CONTEST_FILE'))
 
     @staticmethod
+    def gen_receipt_location(config, subdir):
+        """Return the receipt.csv file location"""
+        return os.path.join(config.get('git_rootdir'),
+                    Globals.get('ROOT_ELECTION_DATA_SUBDIR'),
+                    subdir,
+                    Globals.get('CONTEST_FILE_SUBDIR'),
+                    Globals.get('RECEIPT_FILE'))
+
+    @staticmethod
     def get_cast_from_blank(blank_ballot):
         """Given a blank ballot relative or absolute path, will map that
         to the state/town cast ballot location, which is basically up
@@ -176,11 +185,11 @@ class Ballot:
 
     def clear_selection(self, contest):
         """Clear the selection (as when self adjudicating)"""
-        self.contests[contest.get('ggo')][contest.get('index')][contest.get('name')]['selection'] = []
+        self.contests[contest.get('ggo')][contest.get('index')][contest.get('name')]['selection'] \
+          = []
 
     def add_selection(self, contest, selection_offset):
-        """
-        Will add the specified contest choice (offset into the ordered
+        """Will add the specified contest choice (offset into the ordered
         choices array) to the specified contest.  This is an
         'add' since in plurality one may be voting for more than one
         choice, or in RCV one needs to rank the choices.  In both the
@@ -289,12 +298,13 @@ class Ballot:
 
     def gen_blank_ballot_location(self, config, style='json'):
         """Return the file location of a blank ballot"""
-        return os.path.join(config.get('git_rootdir'),
-                    Globals.get('ROOT_ELECTION_DATA_SUBDIR'),
-                    self.ballot_subdir,
-                    Globals.get('BLANK_BALLOT_SUBDIR'),
-                    style,
-                    self.gen_unique_blank_ballot_name(config, Globals.get('BALLOT_FILE')))
+        return os.path.join(
+            config.get('git_rootdir'),
+            Globals.get('ROOT_ELECTION_DATA_SUBDIR'),
+            self.ballot_subdir,
+            Globals.get('BLANK_BALLOT_SUBDIR'),
+            style,
+            self.gen_unique_blank_ballot_name(config, Globals.get('BALLOT_FILE')))
 
     def write_blank_ballot(self, config, ballot_file='', style='json'):
         """
@@ -385,5 +395,14 @@ class Ballot:
         with open(contest_file, 'w', encoding="utf8") as outfile:
             json.dump(the_aggregate, outfile, sort_keys=True, indent=4, ensure_ascii=False)
         return contest_file
+
+    def write_receipt_csv(self, lines, config):
+        """Write out the voter's ballot receipt"""
+        receipt_file = Ballot.gen_receipt_location(config, self.ballot_subdir)
+        # The parent directory better exist or something is wrong
+        with open(receipt_file, 'w', encoding="utf8") as outfile:
+            for line in lines:
+                outfile.write(f"{line}\n")
+        return receipt_file
 
 # EOF

--- a/bin/ballot.py
+++ b/bin/ballot.py
@@ -194,8 +194,11 @@ class Ballot:
             raise ValueError((f"The selection ({selection_offset}) has already been "
                                   f"selected for contest ({contest_name}) "
                                   f"for GGO ({contest_ggo})"))
-        # pylint: disable=line-too-long
-        self.contests[contest_ggo][contest_index][contest_name]['selection'].append(selection_offset)
+        # For end voter UX, add the selection as the offset + ': ' +
+        # name just because a string is more understandable than json
+        # list syntax
+        self.contests[contest_ggo][contest_index][contest_name]['selection'].append(
+            str(selection_offset) + ':  ' + contest.get['choices'][selection_offset])
 
     def verify_cast_ballot(self):
         """Will validate the ballot contest choices are legitimate.

--- a/bin/ballot.py
+++ b/bin/ballot.py
@@ -168,6 +168,16 @@ class Ballot:
             return self.ballot_node
         raise NameError(f"Name {name} not accepted/defined for Ballot.get()")
 
+    def get_contest_name_by_uid(self, uid):
+        """Given a blank ballot or better, will return the contest name
+        given a uid.  Will raise an error if the ballot does not contain
+        that uid.
+        """
+        for contest in Contests(self):
+            if uid == contest.get('uid'):
+                return contest.get('name')
+        raise KeyError(f"There is no matching contest uid ({uid}) in the supplied balloot")
+
     def dict(self):
         """Return a dictionary of the ballot by making a copy"""
         return dict({'contests': self.contests,

--- a/bin/cast_ballot.py
+++ b/bin/cast_ballot.py
@@ -125,6 +125,9 @@ def get_user_selection(the_ballot, the_contest, count, total_contests):
                 f"{err_string}")
         # if still here, set the selection
         try:
+            # Since it is possible to self adjudicate a contest, always
+            # explicitly clear the selection before adding
+            the_ballot.clear_selection(the_contest)
             for sel in validated_selections:
                 the_ballot.add_selection(the_contest, sel)
         # pylint: disable=broad-except
@@ -144,7 +147,7 @@ def get_user_selection(the_ballot, the_contest, count, total_contests):
                                     blank=True)
     else:
         # Then prompt for input
-        prompt = "Please enter in rank order the numbers of your choices separated by spaces:  "
+        prompt = "Please enter in rank order the numbers of your choices separated by spaces: "
         pyinputplus.inputCustom(validate_multichoice,
                                     prompt=prompt,
                                     blank=True)
@@ -174,13 +177,13 @@ def loop_over_contests(a_ballot):
             # Print the selections
             for contest in contests:
                 print(
-                    f"Contest {contest.get('uid')} ({contest.get('name')})   "
+                    f"Contest {contest.get('uid')} - {contest.get('name')}: "
                     f"{contest.get('selection')}")
-            prompt = "Is this correct?  yes (accepts ballot), no (rejects ballot)"
+            prompt = "Is this correct?  Enter yes to accept the ballot, no to reject the ballot: "
             if 'yes' == pyinputplus.inputYesNo(prompt):
                 break
             prompt = ("Enter a contest uid to redo that contest, "
-                          "enter nothing to start completely over")
+                          "enter nothing (leave blank and hit enter) to start completely over: ")
             response = pyinputplus.inputChoice(contest_uids + [''], prompt)
             if response == '':
                 count = 0
@@ -189,7 +192,7 @@ def loop_over_contests(a_ballot):
                     get_user_selection(a_ballot, contest, count, total_contests)
             else:
                 for contest in contests:
-                    if contest['uid'] == response:
+                    if contest.get('uid') == response:
                         get_user_selection(a_ballot, contest, 1, 1)
                         break
     # For a convenient side effect, return the contests

--- a/bin/common.py
+++ b/bin/common.py
@@ -37,6 +37,8 @@ class Globals:
         # The default location from the CWD of this program, which is different than
         # The location of the incoming ballot.json file etc
         'BALLOT_FILE': 'ballot.json',
+        'CONTEST_FILE': 'contest.json',
+        'RECEIPT_FILE': 'receipt.csv',
         # The blank ballot folder location
         'BLANK_BALLOT_SUBDIR': 'blank-ballots',
         # The location/name of the config and address map files for this GGO
@@ -44,7 +46,6 @@ class Globals:
         'ADDRESS_MAP_FILE': 'address_map.yaml',
         # The location of the contest cvr file
         'CONTEST_FILE_SUBDIR': 'CVRs',
-        'CONTEST_FILE': 'contest.json',
         # The required address fields for an address. To get around
         # the difficulty of creating a completely generic
         # address-to-ballot function at this time, these fields are
@@ -153,7 +154,13 @@ class Shellout:
     @staticmethod
     def cvr_parse_git_log_output(git_log_command, election_config):
         """Will execute the supplied git log command and process the
-        output of those commits that are CVRs
+        output of those commits that are CVRs.  Will return a
+        dictionary keyed on the contest UID that is a list of CVRs.
+        The CVR is just the CVR from the git log with a 'digest' key
+        added.
+
+        Note the the order of the list is git log order and not
+        randomized FWIIW.
         """
         # Will process all the CVR commits on the master branch and tally
         # all the contests found.

--- a/bin/contest.py
+++ b/bin/contest.py
@@ -18,6 +18,7 @@
 """How to manage a VTP specific contest"""
 
 import json
+import re
 import operator
 from logging import debug
 from fractions import Fraction
@@ -194,6 +195,7 @@ class Contest:
             return
         raise ValueError(f"Illegal value for Contest attribute ({name})")
 
+# pylint: disable=too-many-instance-attributes # (8/7 - not worth it at this time)
 class Tally:
     """
     A class to tally ballot contests a.k.a. CVRs.  The three primary
@@ -296,6 +298,9 @@ class Tally:
                 # be interested in verifying the explicit
                 # values
                 selection = contest['selection'][count]
+                # depending on version, selection could be an int or a string
+                if isinstance(selection, str):
+                    selection = int(re.search('(^[0-9]+)', selection).group(1))
                 choice = Contest.get_choices_from_contest(contest['choices'])[selection]
                 self.selection_counts[choice] += 1
                 self.vote_count += 1
@@ -310,6 +315,9 @@ class Tally:
         if len(contest['selection']):
             # the voter can still leave a RCV contest blank
             selection = contest['selection'][0]
+            # depending on version, selection could be an int or a string
+            if isinstance(selection, str):
+                selection = int(re.search('(^[0-9]+)', selection).group(1))
             choice = Contest.get_choices_from_contest(contest['choices'])[selection]
             self.selection_counts[choice] += 1
             self.vote_count += 1


### PR DESCRIPTION
Post some feedback decided it was necessary to add a self adjudication step as would be the case in a more fully adopted VTP 1.0 rollout at a voting center.  In other words, the following command now works:

./vote.py --state=California --town=Oakland --address="123 Main Street"

The above will interactively cast and accept a ballot, storing the ballot receipt (contest receipts) in a file while displaying on STDOUT the voter's row offset.